### PR TITLE
Add Ghidra 11.2 builds; Build Python Modules; Bump version number to 0.3.0. 

### DIFF
--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -185,7 +185,7 @@ jobs:
   # Bundle up a draft release if the version is tagged
   release:
     permissions: write-all
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     needs: [build, build_rust, build_rust_mac_x86_64, build_py]
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -177,7 +177,8 @@ jobs:
       - name: Build wheels
         run: cd search && python -m cibuildwheel --output-dir wheelhouse
         env:
-            CIBW_BEFORE_ALL: "curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y && source $HOME/.cargo/env && rustup update && source $HOME/.cargo/env"
+            CIBW_BEFORE_ALL: "curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y && source $HOME/.cargo/env && rustup update"
+            CIBW_BEFORE_BUILD: "source $HOME/.cargo/env"
       - uses: actions/upload-artifact@v4
         with:
           name: python-wheels-ubuntu

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -175,7 +175,11 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.20.0
       - name: Build wheels
-        run: cd search && python -m cibuildwheel --output-dir wheelhouse
+        run: |
+          source $HOME/.cargo/env
+          which rustc
+          which cargo
+          cd search && python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4
         with:
           name: python-wheels-ubuntu

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: python-wheels-ubuntu
-          path: ./wheelhouse/*.whl
+          path: ./search/wheelhouse/*.whl
 
   # Bundle up a draft release if the version is tagged
   release:

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Build wheels
         run: cd search && python -m cibuildwheel --output-dir wheelhouse
         env:
-            CIBW_BEFORE_ALL: "curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y && rustup update && source $HOME/.cargo/env"
+            CIBW_BEFORE_ALL: "curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y && source $HOME/.cargo/env && rustup update && source $HOME/.cargo/env"
       - uses: actions/upload-artifact@v4
         with:
           name: python-wheels-ubuntu

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -268,7 +268,7 @@ jobs:
             CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
       - uses: actions/upload-artifact@v4
         with:
-          name: python-wheels-${{ matrix.os }}-${{ github.ref_name }}
+          name: python-wheels-${{ matrix.os }}
           path: ./search/wheelhouse/*.whl
 
   # Bundle up a draft release if the version is tagged
@@ -288,7 +288,7 @@ jobs:
       - name: Make zip
         run: |
           cd output_release
-          find . -type d -name 'python-wheels*' -maxdepth 1 -exec zip -r ../\{\}.zip \{\} \;
+          find . -type d -name 'python-wheels*' -maxdepth 1 -exec zip -r ../\{\}-${{ github.ref_name }}.zip \{\} \;
           mkdir ../output_release_coverage
           mv *_coverage_report ../output_release_coverage
           mv pickled_canary_rust_tools_mac_x86_64/treesearchtool pickled_canary_rust_tools/treesearchtool_mac_x86_64

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -162,9 +162,12 @@ jobs:
       - name: Install Dependencies
         run: |
           curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
+          rustup update
           source \$HOME/.cargo/env || export PATH="\$HOME/.cargo/bin:\$PATH"
       - name: test rust
-        run: which rust || env
+        run: |
+          which rust || env
+          cat \$HOME/.cargo/env
       - uses: actions/checkout@v4
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -184,7 +184,7 @@ jobs:
   release:
     permissions: write-all
     runs-on: ubuntu:latest
-    needs: [build, build_rust, build_rust_mac_x86_64]
+    needs: [build, build_rust, build_rust_mac_x86_64, build_py]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
@@ -214,5 +214,5 @@ jobs:
           gh release create --draft ${{ github.ref_name }}
           "pickled_canary-${{ github.ref_name }}.zip"
           "pickled_canary-coverage_reports-${{ github.ref_name }}.zip"
-          "python-wheels-*"
+          python-wheels-*
           --title "Pickled Canary ${{ github.ref_name}}"

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -167,11 +167,7 @@ jobs:
       - name: test rust
         run: |
           which cargo || env
-          echo vvvvvvvv
-          echo $HOME
-          echo wwwwwwwwwwwww
-          echo \$HOME
-          cat $HOME/.cargo/env
+          which rustc || env
       - uses: actions/checkout@v4
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -156,34 +156,28 @@ jobs:
           path: build/reports/jacoco/test/*
 
   build_py:
-    runs-on: ubuntu-latest
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
     needs: []
     steps:
-      # - name: Install Dependencies
-      #   run: |
-      #     curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
-      #     rustup update
-      #     source $HOME/.cargo/env || export PATH="$HOME/.cargo/bin:$PATH"
-      # - name: test rust
-      #   run: |
-      #     which cargo || env
-      #     which rustc || env
       - uses: actions/checkout@v4
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
-
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.20.0
       - name: Build wheels
         run: cd search && python -m cibuildwheel --output-dir wheelhouse
         env:
-            CIBW_BEFORE_ALL: "curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y && source $HOME/.cargo/env && rustup update"
-            CIBW_BEFORE_BUILD: "source $HOME/.cargo/env"
+            CIBW_BEFORE_ALL_LINUX: "curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y && source $HOME/.cargo/env && rustup update"
             CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
             CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
       - uses: actions/upload-artifact@v4
         with:
-          name: python-wheels-ubuntu
+          name: python-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./search/wheelhouse/*.whl
 
   # Bundle up a draft release if the version is tagged

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -162,9 +162,9 @@ jobs:
       - name: Install Dependencies
         run: |
           curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
-          source $HOME/.cargo/env || export PATH="$HOME/.cargo/bin:$PATH"
+          source \$HOME/.cargo/env || export PATH="\$HOME/.cargo/bin:\$PATH"
       - name: test rust
-        run: which rust && env
+        run: which rust || env
       - uses: actions/checkout@v4
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -275,7 +275,7 @@ jobs:
   release:
     permissions: write-all
     runs-on: ubuntu-latest
-    needs: [build, build_rust, build_rust_mac_x86_64, build_py]
+    needs: [build, test, build_rust, build_rust_mac_x86_64, build_py]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Make zip
         run: |
           cd output_release
-          ls -laR 
+          mv python-wheels-* ../
           mkdir ../output_release_coverage
           mv *_coverage_report ../output_release_coverage
           mv pickled_canary_rust_tools_mac_x86_64/treesearchtool pickled_canary_rust_tools/treesearchtool_mac_x86_64

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -177,7 +177,7 @@ jobs:
             CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
       - uses: actions/upload-artifact@v4
         with:
-          name: python-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: python-wheels-${{ matrix.os }}-${{ github.ref_name }}
           path: ./search/wheelhouse/*.whl
 
   # Bundle up a draft release if the version is tagged
@@ -214,4 +214,5 @@ jobs:
           gh release create --draft ${{ github.ref_name }}
           "pickled_canary-${{ github.ref_name }}.zip"
           "pickled_canary-coverage_reports-${{ github.ref_name }}.zip"
+          "python-wheels-*"
           --title "Pickled Canary ${{ github.ref_name}}"

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -159,15 +159,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     steps:
-      - name: Install Dependencies
-        run: |
-          curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
-          rustup update
-          source $HOME/.cargo/env || export PATH="$HOME/.cargo/bin:$PATH"
-      - name: test rust
-        run: |
-          which cargo || env
-          which rustc || env
+      # - name: Install Dependencies
+      #   run: |
+      #     curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
+      #     rustup update
+      #     source $HOME/.cargo/env || export PATH="$HOME/.cargo/bin:$PATH"
+      # - name: test rust
+      #   run: |
+      #     which cargo || env
+      #     which rustc || env
       - uses: actions/checkout@v4
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
@@ -175,11 +175,9 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.20.0
       - name: Build wheels
-        run: |
-          source $HOME/.cargo/env
-          which rustc
-          which cargo
-          cd search && python -m cibuildwheel --output-dir wheelhouse
+        run: cd search && python -m cibuildwheel --output-dir wheelhouse
+        env:
+            CIBW_BEFORE_ALL: "curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y && rustup update && source $HOME/.cargo/env"
       - uses: actions/upload-artifact@v4
         with:
           name: python-wheels-ubuntu

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -162,7 +162,9 @@ jobs:
       - name: Install Dependencies
         run: |
           curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
-          source ~/.cargo/env || export PATH="$HOME/.cargo/bin:$PATH"
+          source $HOME/.cargo/env || export PATH="$HOME/.cargo/bin:$PATH"
+      - name: test rust
+        run: which rust && env
       - uses: actions/checkout@v4
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -213,6 +213,7 @@ jobs:
           cd ../output_release_coverage
           zip -r pickled_canary-coverage_reports-${{ github.ref_name }}.zip *
           mv pickled_canary-coverage_reports-${{ github.ref_name }}.zip ../
+          mv python-wheels-* ../
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -114,6 +114,8 @@ jobs:
             GHIDRA_BUILD_DATE: "20240614"
           - GHIDRA_VERSION: "11.1.2"
             GHIDRA_BUILD_DATE: "20240709"
+          - GHIDRA_VERSION: "11.2"
+            GHIDRA_BUILD_DATE: "20240926"
     env:
       GHIDRA_LABEL: ${{ matrix.GHIDRA_VERSION }}_${{ matrix.GHIDRA_BUILD_DATE }}
     steps:

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -163,10 +163,10 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
           rustup update
-          source \$HOME/.cargo/env || export PATH="\$HOME/.cargo/bin:\$PATH"
+          source $HOME/.cargo/env || export PATH="$HOME/.cargo/bin:$PATH"
       - name: test rust
         run: |
-          which rust || env
+          which cargo || env
           echo vvvvvvvv
           echo $HOME
           echo wwwwwwwwwwwww

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -276,7 +276,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     needs: [build, build_rust, build_rust_mac_x86_64, build_py]
-    # if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - name: Make ouptut directory

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -156,40 +156,30 @@ jobs:
           path: build/reports/jacoco/test/*
 
   build_py:
-    runs-on: quay.io/pypa/manylinux2014_x86_64:latest
+    runs-on: ubuntu-latest
     needs: []
     steps:
       - name: Install Dependencies
         run: |
           curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
           source ~/.cargo/env || export PATH="$HOME/.cargo/bin:$PATH"
-      - name: Build
-        run: |
-          cd search
-          mkdir -p /tmp/wheels/build/
-          for PYBIN in /opt/python/cp*/bin; do
-              rm -rf /tmp/wheels/build/
-              "${PYBIN}/pip" install -U setuptools setuptools-rust wheel pytest
-              "${PYBIN}/pip" wheel . -w dist --no-deps
-          done
-          for whl in dist/*.whl; do
-              auditwheel repair "$whl" -w dist
-          done
-          cd ../
-          for PYBIN in /opt/python/cp*/bin; do
-              "${PYBIN}/pip" install pickled-canary -f search/dist
-              "${PYBIN}/python" -m pytest
-          done
-      - name: Archive Python Modules
-        uses: actions/upload-artifact@v4
+      - uses: actions/checkout@v4
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.20.0
+      - name: Build wheels
+        run: cd search && python -m cibuildwheel --output-dir wheelhouse
+      - uses: actions/upload-artifact@v4
         with:
-          name: pickled_canary-python_modules
-          path: search/dist/*
+          name: python-wheels-ubuntu
+          path: ./wheelhouse/*.whl
 
   # Bundle up a draft release if the version is tagged
   release:
     permissions: write-all
-    runs-on: ubuntu-latest
+    runs-on: ubuntu:latest
     needs: [build, build_rust, build_rust_mac_x86_64]
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -58,7 +58,7 @@ jobs:
           name: pickled_canary_rust_tools
           path: search/target/release/binaries/*
 
-  # This builds and tests the Ghidra plugin
+  # This builds the Ghidra plugin
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -146,20 +146,105 @@ jobs:
         run: |
           gradle build
           gradle
-      - name: Execute Gradle test and coverage
-        env:
-          GHIDRA_INSTALL_DIR: ${{ github.workspace }}/../Ghidra/ghidra_${{ matrix.GHIDRA_VERSION }}_PUBLIC
-        run: gradle test jacocoTestReport
       - name: Archive PC Extension
         uses: actions/upload-artifact@v4
         with:
           name: pickled_canary-${{ env.GHIDRA_LABEL }}
           path: dist/*.zip
+
+  # This tests the Ghidra plugin
+  test:
+    runs-on: ubuntu-latest
+    # This is the same strategy as above... would be great to be able to not duplicate it
+    strategy:
+      matrix:
+        include:
+          # - GHIDRA_VERSION: '9.2.2'
+          #   GHIDRA_BUILD_DATE: "20201229"
+          # - GHIDRA_VERSION: '9.2.4'
+          #   GHIDRA_BUILD_DATE: "20210427"
+          # - GHIDRA_VERSION: "10.0"
+          #   GHIDRA_BUILD_DATE: "20210621"
+          # - GHIDRA_VERSION: "10.0.1"
+          #   GHIDRA_BUILD_DATE: "20210708"
+          # - GHIDRA_VERSION: "10.0.2"
+          #   GHIDRA_BUILD_DATE: "20210804"
+          # - GHIDRA_VERSION: "10.0.3"
+          #   GHIDRA_BUILD_DATE: "20210908"
+          # - GHIDRA_VERSION: "10.1"
+          #   GHIDRA_BUILD_DATE: "20211210"
+          # - GHIDRA_VERSION: "10.1.1"
+          #   GHIDRA_BUILD_DATE: "20211221"
+          # - GHIDRA_VERSION: "10.1.2"
+          #   GHIDRA_BUILD_DATE: "20220125"
+          # - GHIDRA_VERSION: "10.1.3"
+          #   GHIDRA_BUILD_DATE: "20220421"
+          # - GHIDRA_VERSION: "10.1.4"
+          #   GHIDRA_BUILD_DATE: "20220519"
+          # - GHIDRA_VERSION: "10.1.5"
+          #   GHIDRA_BUILD_DATE: "20220726"
+          # - GHIDRA_VERSION: "10.2"
+          #   GHIDRA_BUILD_DATE: "20221101"
+          # - GHIDRA_VERSION: "10.2.1"
+          #   GHIDRA_BUILD_DATE: "20221110"
+          # - GHIDRA_VERSION: "10.2.2"
+          #   GHIDRA_BUILD_DATE: "20221115"
+          # - GHIDRA_VERSION: "10.2.3"
+          #   GHIDRA_BUILD_DATE: "20230208"
+          # - GHIDRA_VERSION: "10.3"
+          #   GHIDRA_BUILD_DATE: "20230510"
+          # - GHIDRA_VERSION: "10.3.1"
+          #   GHIDRA_BUILD_DATE: "20230614"
+          # - GHIDRA_VERSION: "10.3.2"
+          #   GHIDRA_BUILD_DATE: "20230711"
+          # - GHIDRA_VERSION: "10.3.3"
+          #   GHIDRA_BUILD_DATE: "20230829"
+          # - GHIDRA_VERSION: "10.4"
+          #   GHIDRA_BUILD_DATE: "20230928"
+          # - GHIDRA_VERSION: "11.0"
+          #   GHIDRA_BUILD_DATE: "20231222"
+          - GHIDRA_VERSION: "11.1"
+            GHIDRA_BUILD_DATE: "20240607"
+            GHIDRA_JDK_VERSION: 17
+          - GHIDRA_VERSION: "11.1.1"
+            GHIDRA_BUILD_DATE: "20240614"
+            GHIDRA_JDK_VERSION: 17
+          - GHIDRA_VERSION: "11.1.2"
+            GHIDRA_BUILD_DATE: "20240709"
+            GHIDRA_JDK_VERSION: 17
+          - GHIDRA_VERSION: "11.2"
+            GHIDRA_BUILD_DATE: "20240926"
+            GHIDRA_JDK_VERSION: 21
+    env:
+      GHIDRA_LABEL: ${{ matrix.GHIDRA_VERSION }}_${{ matrix.GHIDRA_BUILD_DATE }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest Ghidra version
+        env:
+          GHIDRA_URL: https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${{ matrix.GHIDRA_VERSION }}_build/ghidra_${{ matrix.GHIDRA_VERSION }}_PUBLIC_${{ matrix.GHIDRA_BUILD_DATE }}.zip
+        run: |
+          echo "trying ${{ matrix.GHIDRA_VERSION }} on ${{ matrix.GHIDRA_BUILD_DATE }}"
+          mkdir ../Ghidra && wget --no-check-certificate -O ghidra.zip $GHIDRA_URL && unzip ghidra.zip && rm ghidra.zip && mv ghidra* ../Ghidra
+      - name: Set up JDK ${{ matrix.GHIDRA_JDK_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: "${{ matrix.GHIDRA_JDK_VERSION }}"
+          distribution: "temurin"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.5
+      - name: Execute Gradle test and coverage
+        env:
+          GHIDRA_INSTALL_DIR: ${{ github.workspace }}/../Ghidra/ghidra_${{ matrix.GHIDRA_VERSION }}_PUBLIC
+        run: gradle test jacocoTestReport
       - name: Archive Coverage Report
         uses: actions/upload-artifact@v4
         with:
           name: pickled_canary-${{ env.GHIDRA_LABEL }}_coverage_report
           path: build/reports/jacoco/test/*
+
 
   build_py:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Make zip
         run: |
           cd output_release
-          mv python-wheels-* ../
+          find . -type d -name 'python-wheels*' -maxdepth 1 -exec zip -r ../\{\}.zip \{\} \;
           mkdir ../output_release_coverage
           mv *_coverage_report ../output_release_coverage
           mv pickled_canary_rust_tools_mac_x86_64/treesearchtool pickled_canary_rust_tools/treesearchtool_mac_x86_64

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -64,50 +64,50 @@ jobs:
     strategy:
       matrix:
         include:
-        # - GHIDRA_VERSION: '9.2.2'
-        #   GHIDRA_BUILD_DATE: "20201229"
-        # - GHIDRA_VERSION: '9.2.4'
-        #   GHIDRA_BUILD_DATE: "20210427"
-        # - GHIDRA_VERSION: "10.0"
-        #   GHIDRA_BUILD_DATE: "20210621"
-        # - GHIDRA_VERSION: "10.0.1"
-        #   GHIDRA_BUILD_DATE: "20210708"
-        # - GHIDRA_VERSION: "10.0.2"
-        #   GHIDRA_BUILD_DATE: "20210804"
-        # - GHIDRA_VERSION: "10.0.3"
-        #   GHIDRA_BUILD_DATE: "20210908"
-        # - GHIDRA_VERSION: "10.1"
-        #   GHIDRA_BUILD_DATE: "20211210"
-        # - GHIDRA_VERSION: "10.1.1"
-        #   GHIDRA_BUILD_DATE: "20211221"
-        # - GHIDRA_VERSION: "10.1.2"
-        #   GHIDRA_BUILD_DATE: "20220125"
-        # - GHIDRA_VERSION: "10.1.3"
-        #   GHIDRA_BUILD_DATE: "20220421"
-        # - GHIDRA_VERSION: "10.1.4"
-        #   GHIDRA_BUILD_DATE: "20220519"
-        # - GHIDRA_VERSION: "10.1.5"
-        #   GHIDRA_BUILD_DATE: "20220726"
-        # - GHIDRA_VERSION: "10.2"
-        #   GHIDRA_BUILD_DATE: "20221101"
-        # - GHIDRA_VERSION: "10.2.1"
-        #   GHIDRA_BUILD_DATE: "20221110"
-        # - GHIDRA_VERSION: "10.2.2"
-        #   GHIDRA_BUILD_DATE: "20221115"
-        # - GHIDRA_VERSION: "10.2.3"
-        #   GHIDRA_BUILD_DATE: "20230208"
-        # - GHIDRA_VERSION: "10.3"
-        #   GHIDRA_BUILD_DATE: "20230510"
-        # - GHIDRA_VERSION: "10.3.1"
-        #   GHIDRA_BUILD_DATE: "20230614"
-        # - GHIDRA_VERSION: "10.3.2"
-        #   GHIDRA_BUILD_DATE: "20230711"
-        # - GHIDRA_VERSION: "10.3.3"
-        #   GHIDRA_BUILD_DATE: "20230829"
-        # - GHIDRA_VERSION: "10.4"
-        #   GHIDRA_BUILD_DATE: "20230928"
-        # - GHIDRA_VERSION: "11.0"
-        #   GHIDRA_BUILD_DATE: "20231222"
+          # - GHIDRA_VERSION: '9.2.2'
+          #   GHIDRA_BUILD_DATE: "20201229"
+          # - GHIDRA_VERSION: '9.2.4'
+          #   GHIDRA_BUILD_DATE: "20210427"
+          # - GHIDRA_VERSION: "10.0"
+          #   GHIDRA_BUILD_DATE: "20210621"
+          # - GHIDRA_VERSION: "10.0.1"
+          #   GHIDRA_BUILD_DATE: "20210708"
+          # - GHIDRA_VERSION: "10.0.2"
+          #   GHIDRA_BUILD_DATE: "20210804"
+          # - GHIDRA_VERSION: "10.0.3"
+          #   GHIDRA_BUILD_DATE: "20210908"
+          # - GHIDRA_VERSION: "10.1"
+          #   GHIDRA_BUILD_DATE: "20211210"
+          # - GHIDRA_VERSION: "10.1.1"
+          #   GHIDRA_BUILD_DATE: "20211221"
+          # - GHIDRA_VERSION: "10.1.2"
+          #   GHIDRA_BUILD_DATE: "20220125"
+          # - GHIDRA_VERSION: "10.1.3"
+          #   GHIDRA_BUILD_DATE: "20220421"
+          # - GHIDRA_VERSION: "10.1.4"
+          #   GHIDRA_BUILD_DATE: "20220519"
+          # - GHIDRA_VERSION: "10.1.5"
+          #   GHIDRA_BUILD_DATE: "20220726"
+          # - GHIDRA_VERSION: "10.2"
+          #   GHIDRA_BUILD_DATE: "20221101"
+          # - GHIDRA_VERSION: "10.2.1"
+          #   GHIDRA_BUILD_DATE: "20221110"
+          # - GHIDRA_VERSION: "10.2.2"
+          #   GHIDRA_BUILD_DATE: "20221115"
+          # - GHIDRA_VERSION: "10.2.3"
+          #   GHIDRA_BUILD_DATE: "20230208"
+          # - GHIDRA_VERSION: "10.3"
+          #   GHIDRA_BUILD_DATE: "20230510"
+          # - GHIDRA_VERSION: "10.3.1"
+          #   GHIDRA_BUILD_DATE: "20230614"
+          # - GHIDRA_VERSION: "10.3.2"
+          #   GHIDRA_BUILD_DATE: "20230711"
+          # - GHIDRA_VERSION: "10.3.3"
+          #   GHIDRA_BUILD_DATE: "20230829"
+          # - GHIDRA_VERSION: "10.4"
+          #   GHIDRA_BUILD_DATE: "20230928"
+          # - GHIDRA_VERSION: "11.0"
+          #   GHIDRA_BUILD_DATE: "20231222"
           - GHIDRA_VERSION: "11.1"
             GHIDRA_BUILD_DATE: "20240607"
           - GHIDRA_VERSION: "11.1.1"
@@ -154,6 +154,37 @@ jobs:
         with:
           name: pickled_canary-${{ env.GHIDRA_LABEL }}_coverage_report
           path: build/reports/jacoco/test/*
+
+  build_py:
+    runs-on: quay.io/pypa/manylinux2014_x86_64:latest
+    needs: []
+    steps:
+      - name: Install Dependencies
+        run: |
+          curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
+          source ~/.cargo/env || export PATH="$HOME/.cargo/bin:$PATH"
+      - name: Build
+        run: |
+          cd search
+          mkdir -p /tmp/wheels/build/
+          for PYBIN in /opt/python/cp*/bin; do
+              rm -rf /tmp/wheels/build/
+              "${PYBIN}/pip" install -U setuptools setuptools-rust wheel pytest
+              "${PYBIN}/pip" wheel . -w dist --no-deps
+          done
+          for whl in dist/*.whl; do
+              auditwheel repair "$whl" -w dist
+          done
+          cd ../
+          for PYBIN in /opt/python/cp*/bin; do
+              "${PYBIN}/pip" install pickled-canary -f search/dist
+              "${PYBIN}/python" -m pytest
+          done
+      - name: Archive Python Modules
+        uses: actions/upload-artifact@v4
+        with:
+          name: pickled_canary-python_modules
+          path: search/dist/*
 
   # Bundle up a draft release if the version is tagged
   release:

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -191,7 +191,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     needs: [build, build_rust, build_rust_mac_x86_64, build_py]
-    if: startsWith(github.ref, 'refs/tags/')
+    # if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - name: Make ouptut directory
@@ -203,6 +203,7 @@ jobs:
       - name: Make zip
         run: |
           cd output_release
+          ls -laR 
           mkdir ../output_release_coverage
           mv *_coverage_report ../output_release_coverage
           mv pickled_canary_rust_tools_mac_x86_64/treesearchtool pickled_canary_rust_tools/treesearchtool_mac_x86_64
@@ -213,7 +214,6 @@ jobs:
           cd ../output_release_coverage
           zip -r pickled_canary-coverage_reports-${{ github.ref_name }}.zip *
           mv pickled_canary-coverage_reports-${{ github.ref_name }}.zip ../
-          mv python-wheels-* ../
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -110,12 +110,16 @@ jobs:
           #   GHIDRA_BUILD_DATE: "20231222"
           - GHIDRA_VERSION: "11.1"
             GHIDRA_BUILD_DATE: "20240607"
+            GHIDRA_JDK_VERSION: 17
           - GHIDRA_VERSION: "11.1.1"
             GHIDRA_BUILD_DATE: "20240614"
+            GHIDRA_JDK_VERSION: 17
           - GHIDRA_VERSION: "11.1.2"
             GHIDRA_BUILD_DATE: "20240709"
+            GHIDRA_JDK_VERSION: 17
           - GHIDRA_VERSION: "11.2"
             GHIDRA_BUILD_DATE: "20240926"
+            GHIDRA_JDK_VERSION: 21
     env:
       GHIDRA_LABEL: ${{ matrix.GHIDRA_VERSION }}_${{ matrix.GHIDRA_BUILD_DATE }}
     steps:
@@ -127,10 +131,10 @@ jobs:
         run: |
           echo "trying ${{ matrix.GHIDRA_VERSION }} on ${{ matrix.GHIDRA_BUILD_DATE }}"
           mkdir ../Ghidra && wget --no-check-certificate -O ghidra.zip $GHIDRA_URL && unzip ghidra.zip && rm ghidra.zip && mv ghidra* ../Ghidra
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.GHIDRA_JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "${{ matrix.GHIDRA_JDK_VERSION }}"
           distribution: "temurin"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -179,6 +179,8 @@ jobs:
         env:
             CIBW_BEFORE_ALL: "curl --proto '=https' --tlsv1.2  -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y && source $HOME/.cargo/env && rustup update"
             CIBW_BEFORE_BUILD: "source $HOME/.cargo/env"
+            CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
+            CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
       - uses: actions/upload-artifact@v4
         with:
           name: python-wheels-ubuntu

--- a/.github/workflows/pc_ci.yml
+++ b/.github/workflows/pc_ci.yml
@@ -167,7 +167,11 @@ jobs:
       - name: test rust
         run: |
           which rust || env
-          cat \$HOME/.cargo/env
+          echo vvvvvvvv
+          echo $HOME
+          echo wwwwwwwwwwwww
+          echo \$HOME
+          cat $HOME/.cargo/env
       - uses: actions/checkout@v4
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5

--- a/search/Cargo.lock
+++ b/search/Cargo.lock
@@ -479,7 +479,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "pclib"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitvec",
  "criterion",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "treesearchlib"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitvec",
  "criterion",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "treesearchtool"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitvec",
  "clap",
@@ -793,7 +793,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viz"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitvec",
  "clap",

--- a/search/pclib/Cargo.toml
+++ b/search/pclib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pclib"
 authors = ["Peter <plucia@mitre.org>"]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 license-file = "LICENSE.txt"
 

--- a/search/pcviz/Cargo.toml
+++ b/search/pcviz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viz"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Peter <plucia@mitre.org>"]
 edition = "2018"
 license-file = "LICENSE.txt"

--- a/search/pyproject.toml
+++ b/search/pyproject.toml
@@ -12,3 +12,6 @@ pytest = { version = "^7.1.2", python = ">=3.7" }
 
 [tool.poetry.dev-dependencies]
 black = { version = "^22.6.0", python = ">=3.6.2" }
+
+[tool.cibuildwheel]
+skip = ["*-musllinux_i686"]

--- a/search/pyproject.toml
+++ b/search/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "setuptools-rust"]
 
 [tool.poetry]
 name = "pickled_canary"
-version = "0.2.0"
+version = "0.3.0"
 description = ""
 authors = ["The MITRE Corporation"]
 

--- a/search/setup.py
+++ b/search/setup.py
@@ -5,7 +5,7 @@ from setuptools_rust import Binding, RustExtension
 
 setup(
     name="Pickled-Canary",
-    version="0.2.0",
+    version="0.3.0",
     rust_extensions=[RustExtension("pickled_canary.pickled_canary_lib", binding=Binding.NoBinding, path="pclib/Cargo.toml")],
     packages=["pickled_canary"],
     # rust extensions are not zip safe, just like C-extensions.

--- a/search/treesearchlib/Cargo.toml
+++ b/search/treesearchlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treesearchlib"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Peter <plucia@mitre.org>"]
 edition = "2018"
 license-file = "LICENSE.txt"

--- a/search/treesearchtool/Cargo.toml
+++ b/search/treesearchtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treesearchtool"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Peter <plucia@mitre.org>"]
 edition = "2018"
 license-file = "LICENSE.txt"


### PR DESCRIPTION
Build for Ghidra 11.2
Build python modules for multiple platforms as part of CI.
Bump version number to v0.3.0